### PR TITLE
Backport mux-h1-Always-set-CS_FL_EOI-for-response

### DIFF
--- a/h1-upgrade-2.2.9.patch
+++ b/h1-upgrade-2.2.9.patch
@@ -1,0 +1,23 @@
+diff --git a/src/mux_h1.c b/src/mux_h1.c
+index 840493841..aaed93bf8 100644
+--- a/src/mux_h1.c
++++ b/src/mux_h1.c
+@@ -1406,10 +1406,15 @@ static size_t h1_process_eom(struct h1s *h1s, struct h1m *h1m, struct htx *htx,
+ 	}
+ 
+ 	h1s->flags |= H1S_F_PARSING_DONE;
+-	/* Don't set EOI on the conn-stream for protocol upgrade requests, wait
+-	 * the response to do so or not depending on the status code.
++	/* Set EOI on conn-stream in DONE state iff:
++	 *  - it is a response
++	 *  - it is a request but no a protocol upgrade nor a CONNECT
++	 *
++	 * If not set, Wait the response to do so or not depending on the status
++	 * code.
+ 	 */
+-	if (!(h1m->flags & H1_MF_CONN_UPG))
++	if (((h1m->state == H1_MSG_DONE) && (h1m->flags & H1_MF_RESP)) ||
++	    ((h1m->state == H1_MSG_DONE) && (h1s->meth != HTTP_METH_CONNECT) && !(h1m->flags & H1_MF_CONN_UPG)))
+ 		h1s->cs->flags |= CS_FL_EOI;
+   end:
+ 	TRACE_LEAVE(H1_EV_RX_DATA|H1_EV_RX_EOI, h1s->h1c->conn, h1s,, (size_t[]){ret});

--- a/haproxy22.spec
+++ b/haproxy22.spec
@@ -21,6 +21,8 @@ Source3:        haproxy.logrotate
 Source4:        haproxy.sysconfig
 Source5:        halog.1
 
+Patch0:         h1-upgrade-2.2.9.patch
+
 BuildRequires:  gcc
 BuildRequires:  lua53u-devel
 BuildRequires:  pcre2-devel
@@ -52,6 +54,8 @@ availability environments. Indeed, it can:
 
 %prep
 %setup -q -n haproxy-%{version}
+
+%patch0 -p1
 
 %build
 regparm_opts=


### PR DESCRIPTION
Patch to address #5.

Unfortunately I wasn't able to apply https://github.com/haproxy/haproxy/commit/a22782b597ee9a3bfecb18a66e29633c8e814216 as a patch due to a number of other changes being made to the code since 2.2.9. So i made this patch myself instead. RPM built successfully and seems to work ok with some brief testing after install.