### PR TITLE
HAProxy 2.2.15

### DIFF
--- a/haproxy22.spec
+++ b/haproxy22.spec
@@ -25,7 +25,7 @@ BuildRequires:  gcc
 BuildRequires:  lua53u-devel
 BuildRequires:  pcre2-devel
 BuildRequires:  zlib-devel
-BuildRequires:  openssl-devel
+BuildRequires:  openssl11-devel
 BuildRequires:  systemd-devel
 BuildRequires:  systemd
 
@@ -63,6 +63,8 @@ regparm_opts="USE_REGPARM=1"
     CPU="generic" \
     TARGET="linux-glibc" \
     USE_OPENSSL=1 \
+    SSL_LIB="$(pkg-config --libs-only-L openssl11 | sed -e 's/^-L//')" \
+    SSL_INC="$(pkg-config --cflags-only-I openssl11 | sed -e 's/^-I//')" \
     USE_PCRE2=1 \
     USE_ZLIB=1 \
     USE_LUA=1 \
@@ -154,6 +156,7 @@ exit 0
 %changelog
 * Thu Aug  5 2021 Christian Boenning <christian@boenning.io> - 2.2.15-1
 - Upstream HAProxy 2.2.15
+- Build against OpenSSL 1.1.1
 
 * Fri Mar  5 2021 Christian Boenning <christian@boenning.io> - 2.2.10-1
 - Upstream HAProxy 2.2.10

--- a/haproxy22.spec
+++ b/haproxy22.spec
@@ -7,7 +7,7 @@
 %global _hardened_build 1
 
 Name:           haproxy22
-Version:        2.2.10
+Version:        2.2.15
 Release:        1%{?dist}
 Summary:        HAProxy reverse proxy for high availability environments
 
@@ -152,6 +152,9 @@ exit 0
 %{_mandir}/man1/*
 
 %changelog
+* Thu Aug  5 2021 Christian Boenning <christian@boenning.io> - 2.2.15-1
+- Upstream HAProxy 2.2.15
+
 * Fri Mar  5 2021 Christian Boenning <christian@boenning.io> - 2.2.10-1
 - Upstream HAProxy 2.2.10
 


### PR DESCRIPTION
Update HAProxy to 2.2.15 and build against OpenSSL 1.1.1 from EPEL (#9)

```
# haproxy -vv
HA-Proxy version 2.2.15-5e8f49d 2021/07/16 - https://haproxy.org/
[...snipp...]
Built with multi-threading support (MAX_THREADS=64, default=6).
Built with OpenSSL version : OpenSSL 1.1.1g FIPS  21 Apr 2020
Running on OpenSSL version : OpenSSL 1.1.1g FIPS  21 Apr 2020
OpenSSL library supports TLS extensions : yes
OpenSSL library supports SNI : yes
OpenSSL library supports : TLSv1.0 TLSv1.1 TLSv1.2 TLSv1.3
[...snipp...]

#
```